### PR TITLE
fix #1, fix #2 + evaluate props inside stylesheets if function is pro…

### DIFF
--- a/hyperapp.dev.js
+++ b/hyperapp.dev.js
@@ -1,30 +1,24 @@
 import { h } from "hyperapp";
-import decamelize from "decamelize";
 import scope from "scope-css";
 
-const getTag = target => {
-  if(target.__stylesheetTagName) return target.__stylesheetTagName;
-  const uid = Math.random().toString(32).split(".").pop();
-  return target.__stylesheetTagName = `element-${decamelize(target.name, "-")}-${uid}`;
-}
+const getRandomTag = () => "element-" + Math.random().toString(32).split(".").pop();
 
-const getStylesheet = (target, stylesheet) => {
-  if(target.__stylesheetVNode) return target.__stylesheetVNode;
-  stylesheet = stylesheet.replace(/(\r\n|\n|\r)/gm, "");
+const getStylesheet = (tag, str) => {
+
+
+  const clearStr = str.replace(/(\r\n|\n|\r)/gm, "");
 
   // prefix all selectors to make stylesheet 'scoped' using scope-css package
-  stylesheet = scope(stylesheet, target.__stylesheetTagName);
+  const scopedStylesheet = scope(clearStr, tag);
 
-  // save a reference of the stylesheet within the class instance
-  return target.__stylesheetVNode = h("style", { scoped: true }, stylesheet);
+  return h("style", { scoped: true }, scopedStylesheet);
 }
 
-const functionalStylesheet = styleContent => func => {
-  const tag = getTag(func);
-  const stylesheetNode = getStylesheet(func, styleContent);
-
-  // wrap rendered vnode with a hoc
-  return props => h(tag, null, [ func(props), stylesheetNode ]);
+const functionalStylesheet = style => func => (...args) => {
+  if(typeof style === "function") style = style(...args);
+  const tag = getRandomTag();
+  const stylesheetNode = getStylesheet(tag, style);
+  return h(tag, null, [ func(...args), stylesheetNode ]);
 };
 
 export const stylesheet = (styles, functional) => functionalStylesheet(styles)(functional);


### PR DESCRIPTION
in order to have this working: 

```jsx
export default ({ text, onClick }) => (
  <a onClick={onClick}>
    <Box color="lightblue">{text}</Box>
  </a>
)

```

IE:

```javascript
import { stylesheet } from "../scoped-stylesheet";

import { fonts } from "./styles";

export Box = stylesheet(
  props => `
    :host {
      background: ${props.color};
    }
    ${fonts}
    :host {
      border-radius: 10px;
      padding: 10px;
      box-shadow: 3px 3px 8px #888888;
    }
  `,
  (props, children) => children
)

```
note we can pass down several properties that can be evaluated on our stylesheet. This may look a bit hacky but seems useful 